### PR TITLE
Creating a new API that converts from length to estimated storage size

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -325,14 +325,24 @@ impl AccountsFile {
         })
     }
 
-    /// for each offset in `sorted_offsets`, return the account size
-    pub(crate) fn get_account_sizes(&self, sorted_offsets: &[usize]) -> Vec<usize> {
+    /// for each offset in `sorted_offsets`, get the data size
+    pub(crate) fn get_account_data_lens(&self, sorted_offsets: &[usize]) -> Vec<usize> {
         match self {
-            Self::AppendVec(av) => av.get_account_sizes(sorted_offsets),
+            Self::AppendVec(av) => av.get_account_data_lens(sorted_offsets),
             Self::TieredStorage(ts) => ts
                 .reader()
-                .and_then(|reader| reader.get_account_sizes(sorted_offsets).ok())
+                .and_then(|reader| reader.get_account_data_lens(sorted_offsets).ok())
                 .unwrap_or_default(),
+        }
+    }
+
+    /// Estimate the amount of storage required for the passed in data lengeths
+    pub(crate) fn get_estimated_storage_size(&self, data_lens: &[usize]) -> usize {
+        match self {
+            Self::AppendVec(av) => av.get_estimated_storage_size(data_lens),
+            Self::TieredStorage(ts) => ts
+                .reader()
+                .map_or(0, |reader| reader.get_estimated_storage_size(data_lens)),
         }
     }
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -336,7 +336,7 @@ impl AccountsFile {
         }
     }
 
-    /// Estimate the amount of storage required for the passed in data lengeths
+    /// Estimate the amount of storage required for the passed in data lengths
     pub(crate) fn get_estimated_storage_size(&self, data_lens: &[usize]) -> usize {
         match self {
             Self::AppendVec(av) => av.get_estimated_storage_size(data_lens),

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1095,7 +1095,7 @@ impl AppendVec {
         }
     }
 
-    /// Estimate the amount of storage required for the passed in data lengeths
+    /// Estimate the amount of storage required for the passed in data lengths
     pub(crate) fn get_estimated_storage_size(&self, data_len: &[usize]) -> usize {
         data_len.iter().map(|len| aligned_stored_size(*len)).sum()
     }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -165,8 +165,6 @@ impl IsZeroLamport for IndexInfo {
 struct AccountOffsets {
     /// offset to the end of the &[u8] data
     offset_to_end_of_data: usize,
-    /// # of bytes (aligned) to store this account, including variable sized data
-    stored_size_aligned: usize,
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
@@ -889,14 +887,15 @@ impl AppendVec {
         &self,
         offset: usize,
     ) -> Option<(StoredMeta, solana_account::AccountSharedData)> {
-        let sizes = self.get_account_sizes(&[offset]);
+        let data_len = self.get_account_data_lens(&[offset]);
+        let sizes = self.get_estimated_storage_size(&data_len);
         let result = self.get_stored_account_meta_callback(offset, |r_callback| {
             let r2 = self.get_account_shared_data(offset);
             assert!(solana_account::accounts_equal(
                 &r_callback,
                 r2.as_ref().unwrap()
             ));
-            assert_eq!(sizes, vec![r_callback.stored_size()]);
+            assert_eq!(sizes, r_callback.stored_size());
             let meta = r_callback.meta().clone();
             Some((meta, r_callback.to_account_shared_data()))
         });
@@ -906,7 +905,7 @@ impl AppendVec {
                 .is_none());
             assert!(self.get_account_shared_data(offset).is_none());
             // it has different rules for checking len and returning None
-            assert!(sizes.is_empty());
+            assert!(sizes == 0);
         }
         result.flatten()
     }
@@ -926,12 +925,10 @@ impl AppendVec {
         let stored_size_unaligned = STORE_META_OVERHEAD
             .checked_add(stored_meta.data_len as usize)
             .expect("stored size cannot overflow");
-        let stored_size_aligned = u64_align!(stored_size_unaligned);
         let offset_to_end_of_data = start_offset + stored_size_unaligned;
 
         AccountOffsets {
             offset_to_end_of_data,
-            stored_size_aligned,
         }
     }
 
@@ -1098,8 +1095,13 @@ impl AppendVec {
         }
     }
 
-    /// for each offset in `sorted_offsets`, get the size of the account. No other information is needed for the account.
-    pub(crate) fn get_account_sizes(&self, sorted_offsets: &[usize]) -> Vec<usize> {
+    /// Estimate the amount of storage required for the passed in data lengeths
+    pub(crate) fn get_estimated_storage_size(&self, data_len: &[usize]) -> usize {
+        data_len.iter().map(|len| aligned_stored_size(*len)).sum()
+    }
+
+    /// for each offset in `sorted_offsets`, get the the amount of data stored in the account.
+    pub(crate) fn get_account_data_lens(&self, sorted_offsets: &[usize]) -> Vec<usize> {
         // self.len() is an atomic load, so only do it once
         let self_len = self.len();
         let mut account_sizes = Vec::with_capacity(sorted_offsets.len());
@@ -1115,7 +1117,7 @@ impl AppendVec {
                         // data doesn't fit, so don't include
                         break;
                     }
-                    account_sizes.push(next.stored_size_aligned);
+                    account_sizes.push(stored_meta.data_len as usize);
                 }
             }
             AppendVecFileBacking::File(file) => {
@@ -1143,7 +1145,7 @@ impl AppendVec {
                         // data doesn't fit, so don't include
                         break;
                     }
-                    account_sizes.push(next.stored_size_aligned);
+                    account_sizes.push(stored_meta.data_len as usize);
                 }
             }
         }
@@ -1699,7 +1701,7 @@ pub mod tests {
         let size = 1000;
         let mut indexes = vec![];
         let now = Instant::now();
-        let mut sizes = vec![];
+        let mut sizes: Vec<usize> = vec![];
         for sample in 0..size {
             // sample + 1 is so sample = 0 won't be used.
             // sample = 0 produces default account with default pubkey
@@ -1708,7 +1710,10 @@ pub mod tests {
             let pos = av.append_account_test(&account).unwrap();
             assert_eq!(av.get_account_test(pos).unwrap(), account);
             indexes.push(pos);
-            assert_eq!(sizes, av.get_account_sizes(&indexes));
+            assert_eq!(
+                sizes.iter().sum::<usize>(),
+                av.get_estimated_storage_size(&av.get_account_data_lens(indexes.as_slice()))
+            );
         }
         trace!("append time: {} ms", now.elapsed().as_millis());
 
@@ -2071,8 +2076,10 @@ pub mod tests {
         let (append_vec, _) =
             AppendVec::new_from_file(&temp_file.path, total_stored_size, storage_access).unwrap();
 
-        let account_sizes = append_vec.get_account_sizes(account_offsets.as_slice());
-        assert_eq!(account_sizes, stored_sizes);
+        let account_sizes = append_vec.get_estimated_storage_size(
+            &append_vec.get_account_data_lens(account_offsets.as_slice()),
+        );
+        assert_eq!(account_sizes, total_stored_size);
     }
 
     /// A helper function for testing different scenario for scan_*.

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -613,8 +613,13 @@ impl HotStorageReader {
         Ok(())
     }
 
-    /// for each offset in `sorted_offsets`, return the account size
-    pub(crate) fn get_account_sizes(
+    /// Estimate the amount of storage required for the passed in data lengths
+    pub(crate) fn get_estimated_storage_size(&self, data_len: &[usize]) -> usize {
+        data_len.iter().map(|data_len| stored_size(*data_len)).sum()
+    }
+
+    /// for each offset in `sorted_offsets`, return the length of data stored in the account
+    pub(crate) fn get_account_data_lens(
         &self,
         sorted_offsets: &[usize],
     ) -> TieredStorageResult<Vec<usize>> {
@@ -625,7 +630,7 @@ impl HotStorageReader {
             let meta = self.get_account_meta_from_offset(account_offset)?;
             let account_block = self.get_account_block(account_offset, index_offset)?;
             let data_len = meta.account_data_size(account_block);
-            result.push(stored_size(data_len));
+            result.push(data_len);
         }
         Ok(result)
     }

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -171,13 +171,20 @@ impl TieredStorageReader {
         }
     }
 
-    /// for each offset in `sorted_offsets`, return the account size
-    pub(crate) fn get_account_sizes(
+    /// Estimate the amount of storage required for the passed in data lengths
+    pub(crate) fn get_estimated_storage_size(&self, data_len: &[usize]) -> usize {
+        match self {
+            Self::Hot(hot) => hot.get_estimated_storage_size(data_len),
+        }
+    }
+
+    /// for each offset in `sorted_offsets`, return the length of data stored in the account
+    pub(crate) fn get_account_data_lens(
         &self,
         sorted_offsets: &[usize],
     ) -> TieredStorageResult<Vec<usize>> {
         match self {
-            Self::Hot(hot) => hot.get_account_sizes(sorted_offsets),
+            Self::Hot(hot) => hot.get_account_data_lens(sorted_offsets),
         }
     }
 


### PR DESCRIPTION
Note*** This is to double checking the direction. Built on top of account_storage_reader to show the entire change, but the API changes would be cleaned up and pushed first*** 

#### Problem
Storing stored_account_size in account storage reader is storing information that is specific to the append vector in the account storage entry and shouldn't be done



#### Summary of Changes
- Store the data length instead
- Expose an API to convert data length to an estimated storage space.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
